### PR TITLE
Feature: Retrieve Nested Links

### DIFF
--- a/lib/crawler.rb
+++ b/lib/crawler.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'nokogiri'
+require 'open-uri'
+
+class Crawler
+  class << self
+    def crawl_internal_links(domain)
+      page = Nokogiri::HTML(open(domain))
+
+      page.search('a').map do |link|
+        link['href'] if valid_internal_link(link['href'])
+      end.compact
+    end
+
+    private
+
+    def valid_internal_link(link)
+      link.start_with?('/') &&
+        %r{\/\b[a-zA-Z]*\b}.match?(link)
+    end
+  end
+end

--- a/lib/site_mapper.rb
+++ b/lib/site_mapper.rb
@@ -1,15 +1,59 @@
 # frozen_string_literal: true
 
+require 'set'
+
 class SiteMapper
   attr_reader :domain
-  attr_accessor :links
+  attr_accessor :site_map, :encountered_paths
 
   def initialize(domain)
     @domain = domain
-    @links = [domain]
+    @site_map = { "#{domain}": {} }
+    @encountered_paths = Set.new
   end
 
-  def retrieve_internal_links
-    links + Crawler.crawl_internal_links(domain)
+  def map_site
+    retrieve_internal_links([domain])
+  end
+
+  def retrieve_internal_links(paths)
+    retrieved_paths = nil
+
+    paths.each do |path|
+      full_path = build_path(path)
+
+      retrieved_paths = Crawler.crawl_internal_links(full_path)
+      add_to_site_map(retrieved_paths)
+    end
+
+    unless retrieved_paths_mapped_already(retrieved_paths)
+      retrieve_internal_links(retrieved_paths)
+    end
+
+    site_map
+  end
+
+  private
+
+  def build_path(path)
+    return domain if path == domain
+
+    domain + path
+  end
+
+  def add_to_site_map(paths)
+    paths.each do |path|
+      next if encountered_paths.include?(path)
+
+      site_map[domain.to_sym][path.to_sym] = {}
+    end
+
+    encountered_paths.merge(paths)
+  end
+
+  def retrieved_paths_mapped_already(paths)
+    paths.any? do |path|
+      !site_map.keys.include?(path)
+    end
   end
 end

--- a/lib/site_mapper.rb
+++ b/lib/site_mapper.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-require 'open-uri'
-
 class SiteMapper
   attr_reader :domain
   attr_accessor :links
@@ -12,18 +9,7 @@ class SiteMapper
     @links = [domain]
   end
 
-  def retrieve_links
-    page = Nokogiri::HTML(open(domain))
-
-    page.search('a').map do |link|
-      links << link['href'] if valid_link(link['href'])
-    end.compact
-
-    links
-  end
-
-  def valid_link(link)
-    link.start_with?('/') &&
-      %r{\/\b[a-zA-Z]*\b}.match?(link)
+  def retrieve_internal_links
+    links + Crawler.crawl_internal_links(domain)
   end
 end

--- a/lib/site_mapper.rb
+++ b/lib/site_mapper.rb
@@ -20,14 +20,16 @@ class SiteMapper
     retrieved_paths = nil
 
     paths.each do |path|
+      next if encountered_paths.include?(path)
+
+      encountered_paths.add(path)
       full_path = build_path(path)
 
       retrieved_paths = Crawler.crawl_internal_links(full_path)
       add_to_site_map(retrieved_paths)
-    end
 
-    unless retrieved_paths_mapped_already(retrieved_paths)
-      retrieve_internal_links(retrieved_paths)
+      unmapped_paths = retrieved_paths_not_mapped(retrieved_paths)
+      retrieve_internal_links(unmapped_paths)
     end
 
     site_map
@@ -45,15 +47,21 @@ class SiteMapper
     paths.each do |path|
       next if encountered_paths.include?(path)
 
-      site_map[domain.to_sym][path.to_sym] = {}
-    end
+      map_position = site_map[domain.to_sym]
+      path_elements = path.split('/').reject(&:empty?)
 
-    encountered_paths.merge(paths)
+      path_elements.each do |element|
+        key = "/#{element}".to_sym
+
+        map_position[key] = {} if map_position[key].nil?
+        map_position = map_position[key]
+      end
+    end
   end
 
-  def retrieved_paths_mapped_already(paths)
-    paths.any? do |path|
-      !site_map.keys.include?(path)
+  def retrieved_paths_not_mapped(paths)
+    paths.reject do |path|
+      encountered_paths.include?(path)
     end
   end
 end

--- a/spec/lib/crawler_spec.rb
+++ b/spec/lib/crawler_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require './lib/crawler'
+
+RSpec.describe Crawler do
+  describe '.crawl_internal_links' do
+    let(:domain) { 'https://monzo.com' }
+    let(:html_body) do
+      <<-HTML
+        <html>
+          <head><title>Monzo - The Bank of the Future</title></head>
+          <body>
+            <header>
+              <div>
+                <a href="/" title="Monzo Home Page">Monzo</a>
+                <nav>
+                  <a href="/about">About</a>
+                  <a href="/blog">Blog</a>
+                  <a href="/community">Community</a>
+                  <a href="/help">Help</a>
+                </nav>
+              </div>
+            </header>
+          </body>
+          <footer>
+            <div>
+              <nav>
+                <a href="https://twitter.com">Twitter</a>
+                <a href="https://facebook.com">Facebook</a>
+                <a href="https://instagram.com">Instagram</a>
+              </nav>
+            </div>
+          </footer>
+        </html
+      HTML
+    end
+
+    let(:expected_links) do
+      %w[
+        /about
+        /blog
+        /community
+        /help
+      ]
+    end
+
+    let(:unexpected_links) do
+      %w[
+        /
+        https://twitter.com
+        https://facebook.com
+        https://instagram.com
+      ]
+    end
+
+    before do
+      expect(described_class).to receive(:open).and_return(html_body)
+    end
+
+    it 'returns internal links for a given domain' do
+      retrieved_links = described_class.crawl_internal_links(domain)
+
+      aggregate_failures do
+        unexpected_links.each do |bad_link|
+          expect(retrieved_links).not_to include(bad_link)
+        end
+
+        expect(retrieved_links).to match_array(expected_links)
+      end
+    end
+  end
+end

--- a/spec/lib/site_mapper_spec.rb
+++ b/spec/lib/site_mapper_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe SiteMapper do
   describe '#retrieve_internal_links' do
     let(:domain) { 'https://monzo.com' }
 
-    let(:crawled_links) do
+    subject { described_class.new(domain) }
+
+    let(:first_links) do
       %w[
         /about
         /blog
@@ -17,18 +19,26 @@ RSpec.describe SiteMapper do
       ]
     end
 
-    let(:expected_links) do
-      [domain] + crawled_links
-    end
+    context 'no nested links' do
+      let(:expected_links) do
+        {
+          "#{domain}": {
+            "/about": {},
+            "/blog": {},
+            "/community": {},
+            "/help": {}
+          }
+        }
+      end
 
-    subject { described_class.new(domain) }
+      before do
+        allow(Crawler).to receive(:crawl_internal_links)
+          .and_return(first_links)
+      end
 
-    before do
-      allow(Crawler).to receive(:crawl_internal_links).and_return(crawled_links)
-    end
-
-    it 'returns internal links for a given domain' do
-      expect(subject.retrieve_internal_links).to eq(expected_links)
+      it 'returns internal links for a given domain' do
+        expect(subject.map_site).to eq(expected_links)
+      end
     end
   end
 end

--- a/spec/lib/site_mapper_spec.rb
+++ b/spec/lib/site_mapper_spec.rb
@@ -1,44 +1,15 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require './lib/crawler'
 require './lib/site_mapper'
 
 RSpec.describe SiteMapper do
-  describe '#retrieve_links' do
+  describe '#retrieve_internal_links' do
     let(:domain) { 'https://monzo.com' }
-    let(:html_body) do
-      <<-HTML
-        <html>
-          <head><title>Monzo - The Bank of the Future</title></head>
-          <body>
-            <header>
-              <div>
-                <a href="/" title="Monzo Home Page">Monzo</a>
-                <nav>
-                  <a href="/about">About</a>
-                  <a href="/blog">Blog</a>
-                  <a href="/community">Community</a>
-                  <a href="/help">Help</a>
-                </nav>
-              </div>
-            </header>
-          </body>
-          <footer>
-            <div>
-              <nav>
-                <a href="https://twitter.com">Twitter</a>
-                <a href="https://facebook.com">Facebook</a>
-                <a href="https://instagram.com">Instagram</a>
-              </nav>
-            </div>
-          </footer>
-        </html
-      HTML
-    end
 
-    let(:expected_links) do
+    let(:crawled_links) do
       %w[
-        https://monzo.com
         /about
         /blog
         /community
@@ -46,31 +17,18 @@ RSpec.describe SiteMapper do
       ]
     end
 
-    let(:unexpected_links) do
-      %w[
-        /
-        https://twitter.com
-        https://facebook.com
-        https://instagram.com
-      ]
+    let(:expected_links) do
+      [domain] + crawled_links
     end
 
     subject { described_class.new(domain) }
 
     before do
-      expect(subject).to receive(:open).and_return(html_body)
+      allow(Crawler).to receive(:crawl_internal_links).and_return(crawled_links)
     end
 
     it 'returns internal links for a given domain' do
-      retrieved_links = subject.retrieve_links
-
-      aggregate_failures do
-        unexpected_links.each do |bad_link|
-          expect(retrieved_links).not_to include(bad_link)
-        end
-
-        expect(retrieved_links).to match_array(expected_links)
-      end
+      expect(subject.retrieve_internal_links).to eq(expected_links)
     end
   end
 end


### PR DESCRIPTION
The SiteMapper class will now correctly nest links into the site map.


This also ensures we do not request pages that have already been requested nor do we add to the site
map if the path has already been visited