### PR TITLE
Add missing `lib/` from README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 Creates a map of a given site via its internal links
 
-To run the crawler, simply clone the repository and run `ruby site_mapper.rb <insert-domain>`
+To run the crawler, simply clone the repository and run `ruby lib/site_mapper.rb <insert-domain>`
 from within the app directory


### PR DESCRIPTION
The previous instructions were incorrect. 