### PR TITLE
Enhancement: Add Executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Crawler
 
-Creates a map of a given site via its internal links
+A small ruby app that creates a map of a given site via its internal links
 
-To run the crawler, simply clone the repository and run `ruby lib/site_mapper.rb <insert-domain>`
-from within the app directory
+
+## Installation
+
+1. Clone the repository
+
+2. Install the gems
+
+```
+bundle install
+```
+
+## Usage
+
+To run the crawler simply call the executable file from within the app directory
+and pass it a domain to crawl:
+
+```
+./crawl <your-domain>
+```

--- a/crawl
+++ b/crawl
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require './lib/site_mapper'
+
+puts SiteMapper.new(ARGV.first).map_site

--- a/lib/site_mapper.rb
+++ b/lib/site_mapper.rb
@@ -70,5 +70,3 @@ class SiteMapper
     end
   end
 end
-
-puts SiteMapper.new(ARGV.first).map_site

--- a/lib/site_mapper.rb
+++ b/lib/site_mapper.rb
@@ -14,6 +14,8 @@ class SiteMapper
   end
 
   def map_site
+    return puts 'Please provide a domain to crawl' if domain.nil?
+
     retrieve_internal_links([domain])
   end
 

--- a/spec/lib/site_mapper_spec.rb
+++ b/spec/lib/site_mapper_spec.rb
@@ -5,10 +5,31 @@ require './lib/crawler'
 require './lib/site_mapper'
 
 RSpec.describe SiteMapper do
-  describe '#retrieve_internal_links' do
-    let(:domain) { 'https://monzo.com' }
+  subject { described_class.new(domain) }
+  let(:domain) { 'https://monzo.com' }
 
-    subject { described_class.new(domain) }
+  describe '#map_site' do
+    context 'when the domain is present' do
+      it 'calls #retrieve_internal_links' do
+        expect(subject).to receive(:retrieve_internal_links)
+          .with(array_including(domain))
+
+        subject.map_site
+      end
+    end
+
+    context 'when the domain is nil' do
+      let(:domain) { nil }
+
+      it 'prompts the user to provide a domain' do
+        expect { subject.map_site }
+          .to output("Please provide a domain to crawl\n")
+          .to_stdout
+      end
+    end
+  end
+
+  describe '#retrieve_internal_links' do
 
     let(:first_links) do
       %w[


### PR DESCRIPTION
Create an executable to run the crawler. This means that requiring the SiteMapper class won't intrinsically run the crawler