### PR TITLE
Feature: Handle Unexpected Responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 gem 'byebug', '~> 8.2.1'
+gem 'faraday', '~> 0.15.4'
 gem 'nokogiri', '~> 1.8.4'
 gem 'rspec', '~> 3.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,10 @@ GEM
   specs:
     byebug (8.2.1)
     diff-lcs (1.3)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
     mini_portile2 (2.3.0)
+    multipart-post (2.0.0)
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     rspec (3.7.0)
@@ -24,6 +27,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug (~> 8.2.1)
+  faraday (~> 0.15.4)
   nokogiri (~> 1.8.4)
   rspec (~> 3.7.0)
 

--- a/lib/crawler.rb
+++ b/lib/crawler.rb
@@ -1,21 +1,23 @@
 # frozen_string_literal: true
 
 require 'nokogiri'
-require 'open-uri'
+require 'faraday'
 
 class Crawler
   class << self
-    def crawl_internal_links(domain)
-      page = Nokogiri::HTML(open(URI.encode(domain)))
+    TIMEOUT = 0.5
 
+    def crawl_internal_links(domain)
+      res = response(domain)
+
+      return nil if res.status == 404
+
+      page = Nokogiri::HTML(res.body)
       page.search('a').map do |link|
         next if link['href'].nil?
 
         link['href'] if valid_internal_link(link['href'])
       end.compact
-
-    rescue OpenURI::HTTPError
-      puts "Couldn't retrieve links from #{domain}"
     end
 
     private
@@ -23,6 +25,20 @@ class Crawler
     def valid_internal_link(link)
       link.start_with?('/') &&
         %r{\/\b[a-zA-Z]*\b}.match?(link)
+    end
+
+    def connection(domain)
+      Faraday.new(url: domain) do |faraday|
+        faraday.request  :url_encoded
+        faraday.response :logger
+        faraday.adapter  Faraday.default_adapter
+      end
+    end
+
+    def response(domain)
+      connection(domain).get do |request|
+        request.options.timeout = TIMEOUT
+      end
     end
   end
 end

--- a/lib/crawler.rb
+++ b/lib/crawler.rb
@@ -6,7 +6,7 @@ require 'faraday'
 class Crawler
   class << self
     TIMEOUT = 0.5
-    BAD_HTTP_STATUSES = [404, 302, 301].freeze
+    BAD_HTTP_STATUSES = [500, 404, 302, 301].freeze
 
     def crawl_internal_links(domain)
       res = response(domain)

--- a/lib/crawler.rb
+++ b/lib/crawler.rb
@@ -6,11 +6,12 @@ require 'faraday'
 class Crawler
   class << self
     TIMEOUT = 0.5
+    BAD_HTTP_STATUSES = [404, 302, 301].freeze
 
     def crawl_internal_links(domain)
       res = response(domain)
 
-      return nil if res.status == 404
+      return nil if BAD_HTTP_STATUSES.include? res.status
 
       page = Nokogiri::HTML(res.body)
       page.search('a').map do |link|

--- a/lib/crawler.rb
+++ b/lib/crawler.rb
@@ -2,44 +2,61 @@
 
 require 'nokogiri'
 require 'faraday'
+require 'URI'
 
 class Crawler
-  class << self
-    TIMEOUT = 0.5
-    BAD_HTTP_STATUSES = [500, 404, 302, 301].freeze
+  TIMEOUT = 0.5
+  BAD_HTTP_STATUSES = [500, 404, 302].freeze
 
-    def crawl_internal_links(domain)
-      res = response(domain)
+  attr_reader :base_domain
 
-      return nil if BAD_HTTP_STATUSES.include? res.status
+  def initialize(starting_point)
+    raise 'Please provide a domain to crawl' if starting_point.nil?
 
-      page = Nokogiri::HTML(res.body)
-      page.search('a').map do |link|
-        next if link['href'].nil?
+    @base_domain = extract_base_url(starting_point)
+  end
 
-        link['href'] if valid_internal_link(link['href'])
-      end.compact
+  def crawl_internal_links(domain)
+    res = response(domain)
+
+    return nil if BAD_HTTP_STATUSES.include? res.status
+
+    page = Nokogiri::HTML(res.body)
+    page.search('a').map do |link|
+      next if link['href'].nil?
+
+      link['href'] if valid_internal_link(link['href'])
+    end.compact
+  end
+
+  private
+
+  def extract_base_url(absolute_url)
+    uri = URI(absolute_url)
+
+    uri.to_s.chomp(uri.path)
+  end
+
+  def valid_internal_link(link)
+    link.start_with?(base_domain) || link_is_relative(link)
+  end
+
+  def link_is_relative(link)
+    link.start_with?('/') &&
+      %r{\/\b[a-zA-Z]*\b}.match?(link)
+  end
+
+  def connection(domain)
+    Faraday.new(url: domain) do |faraday|
+      faraday.request  :url_encoded
+      faraday.response :logger
+      faraday.adapter  Faraday.default_adapter
     end
+  end
 
-    private
-
-    def valid_internal_link(link)
-      link.start_with?('/') &&
-        %r{\/\b[a-zA-Z]*\b}.match?(link)
-    end
-
-    def connection(domain)
-      Faraday.new(url: domain) do |faraday|
-        faraday.request  :url_encoded
-        faraday.response :logger
-        faraday.adapter  Faraday.default_adapter
-      end
-    end
-
-    def response(domain)
-      connection(domain).get do |request|
-        request.options.timeout = TIMEOUT
-      end
+  def response(domain)
+    connection(domain).get do |request|
+      request.options.timeout = TIMEOUT
     end
   end
 end

--- a/lib/site_mapper.rb
+++ b/lib/site_mapper.rb
@@ -5,17 +5,16 @@ require './lib/crawler'
 
 class SiteMapper
   attr_reader :domain
-  attr_accessor :site_map, :encountered_paths
+  attr_accessor :site_map, :encountered_paths, :crawler
 
   def initialize(domain)
     @domain = domain
     @site_map = { "#{domain}": {} }
     @encountered_paths = Set.new
+    @crawler = ::Crawler.new(domain)
   end
 
   def map_site
-    return puts 'Please provide a domain to crawl' if domain.nil?
-
     retrieve_internal_links([domain])
   end
 
@@ -30,7 +29,7 @@ class SiteMapper
       encountered_paths.add(path)
       full_path = build_path(path)
 
-      retrieved_paths = ::Crawler.crawl_internal_links(full_path)
+      retrieved_paths = crawler.crawl_internal_links(full_path)
       next if retrieved_paths.nil?
 
       add_to_site_map(retrieved_paths)
@@ -45,7 +44,7 @@ class SiteMapper
   private
 
   def build_path(path)
-    return domain if path == domain
+    return path if path.start_with?(domain)
 
     domain + path
   end

--- a/spec/lib/crawler_spec.rb
+++ b/spec/lib/crawler_spec.rb
@@ -99,11 +99,7 @@ RSpec.describe Crawler do
         let(:response_mock) { double('Response Mock', status: 404) }
 
         it 'does not scrape the page and returns nil' do
-          expect(Nokogiri::HTML::Document).not_to receive(:parse).with(any_args)
-
-          retrieved_links = described_class.crawl_internal_links(bad_domain)
-
-          expect(retrieved_links).to be_nil
+          does_not_scrape_page(bad_domain)
         end
       end
 
@@ -112,13 +108,28 @@ RSpec.describe Crawler do
         let(:response_mock) { double('Response Mock', status: 302) }
 
         it 'does not scrape the page and returns nil' do
-          expect(Nokogiri::HTML::Document).not_to receive(:parse).with(any_args)
+          does_not_scrape_page(bad_domain)
+        end
+      end
 
-          retrieved_links = described_class.crawl_internal_links(bad_domain)
+      context 'when the response returns a 500' do
+        let(:bad_domain) { 'https://500.com/not-a-page' }
+        let(:response_mock) { double('Response Mock', status: 500) }
 
-          expect(retrieved_links).to be_nil
+        it 'does not scrape the page and returns nil' do
+          does_not_scrape_page(bad_domain)
         end
       end
     end
+  end
+
+  private
+
+  def does_not_scrape_page(bad_domain)
+    expect(Nokogiri::HTML::Document).not_to receive(:parse).with(any_args)
+
+    retrieved_links = described_class.crawl_internal_links(bad_domain)
+
+    expect(retrieved_links).to be_nil
   end
 end

--- a/spec/lib/site_mapper_spec.rb
+++ b/spec/lib/site_mapper_spec.rb
@@ -7,6 +7,7 @@ require './lib/site_mapper'
 RSpec.describe SiteMapper do
   subject { described_class.new(domain) }
   let(:domain) { 'https://monzo.com' }
+  let(:crawler) { Crawler.new(domain) }
 
   describe '#map_site' do
     context 'when the domain is present' do
@@ -23,8 +24,7 @@ RSpec.describe SiteMapper do
 
       it 'prompts the user to provide a domain' do
         expect { subject.map_site }
-          .to output("Please provide a domain to crawl\n")
-          .to_stdout
+          .to raise_error('Please provide a domain to crawl')
       end
     end
   end
@@ -52,7 +52,8 @@ RSpec.describe SiteMapper do
       end
 
       before do
-        allow(Crawler).to receive(:crawl_internal_links)
+        allow(subject).to receive(:crawler).and_return(crawler)
+        allow(crawler).to receive(:crawl_internal_links)
           .and_return(first_links)
       end
 
@@ -99,7 +100,8 @@ RSpec.describe SiteMapper do
         subject.site_map = initial_site_map
         subject.encountered_paths = Set[first_links]
 
-        allow(Crawler).to receive(:crawl_internal_links)
+        allow(subject).to receive(:crawler).and_return(crawler)
+        allow(crawler).to receive(:crawl_internal_links)
           .and_return(about_nested_links)
       end
 

--- a/spec/lib/site_mapper_spec.rb
+++ b/spec/lib/site_mapper_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe SiteMapper do
   end
 
   describe '#retrieve_internal_links' do
-
     let(:first_links) do
       %w[
         /about


### PR DESCRIPTION
Now handles 500, 404, or 302 responses better. This also sets a timeout for the request so that we aren't waiting a long time for a page to respond. Because the responses are just raw HTML, the response should be very quick; I've set the timeout to 0.5 seconds for now.